### PR TITLE
Windows Terminal: Capture `$?` before `Get-History` clobbers the exit code mark

### DIFF
--- a/posh/Settings/40-WindowsTerminal.ps1
+++ b/posh/Settings/40-WindowsTerminal.ps1
@@ -35,9 +35,9 @@ Set-WindowsTerminalGlobalVariables
 Function Global:__Get-LastExitCodeForWinTerm {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseApprovedVerbs', '')]
     [OutputType([Int32])]
-    Param()
+    Param([Boolean]$LastCmdSucceeded, [Int32]$ExitCode)
 
-    if ($? -eq $true) {
+    if ($LastCmdSucceeded) {
         return 0
     }
 
@@ -48,7 +48,7 @@ Function Global:__Get-LastExitCodeForWinTerm {
         return -1
     }
 
-    return $LASTEXITCODE
+    return $ExitCode
 }
 
 # Shell Integration
@@ -58,12 +58,18 @@ Function Global:Prompt {
     [OutputType([String])]
     Param()
 
+    # Capture $? before the Get-History below resets it to $true, then hand it to
+    # __Get-LastExitCodeForWinTerm. That function used to re-read $? *after* the reset and
+    # so always reported success in the OSC 133;D command-finished mark. ($LASTEXITCODE is
+    # unaffected by Get-History, so it is passed directly at the call site below.)
+    $LastCmdSucceeded = $?
+
     # Skip emitting an end of command mark for the first command
     $LastHistoryEntry = Get-History -Count 1
     if ($Global:__LastHistoryId -ne -1) {
         if ($LastHistoryEntry.Id -ne $Global:__LastHistoryId) {
             # Mark end of last command with exit code
-            $LastExitCodeForWinTerm = __Get-LastExitCodeForWinTerm
+            $LastExitCodeForWinTerm = __Get-LastExitCodeForWinTerm -LastCmdSucceeded $LastCmdSucceeded -ExitCode $LASTEXITCODE
             # `OSC FinalTerm ; CmdEnd ; <ExitCode> ST`
             $Prompt = "$([Char]27)]133;D;${LastExitCodeForWinTerm}`a"
         } else {


### PR DESCRIPTION
### Problem

The Windows Terminal shell-integration prompt wrapper in `posh/Settings/40-WindowsTerminal.ps1` runs `Get-History -Count 1` *before* calling `__Get-LastExitCodeForWinTerm`, and `Get-History` resets `$?` to `$true`. Because that function read `$?` to decide success vs failure, it always observed success — so the `OSC 133 ; D ; <code>` ("command finished") FinalTerm mark reported exit code `0` even when the last command failed, and Windows Terminal marked every command as successful in its per-command decoration.

### Fix

Capture `$?` as the wrapper's first statement (before `Get-History` runs) and pass it — together with `$LASTEXITCODE` — into `__Get-LastExitCodeForWinTerm`, instead of having that function re-read the already-clobbered automatic. `$LASTEXITCODE` is unaffected by `Get-History`, so it's passed directly at the call site.

### Notes

- One file; no behavioural change to the success path, the no-history-entry path, or the PowerShell-error (`-1`) path.
- Verified in an interactive `pwsh` session: the `133;D` mark now reports the real native exit code (e.g. `96`) on failure, `0` on success, and `-1` for a PowerShell error.
- No new `PSScriptAnalyzer` findings versus the baseline.